### PR TITLE
feat(components): add Radio and RadioGroup components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ dist
 build
 release
 
-### Coverage output ###
+### Tests output ###
+.vitest
 coverage

--- a/packages/components/lib/components/Button/Button.test.tsx
+++ b/packages/components/lib/components/Button/Button.test.tsx
@@ -53,4 +53,46 @@ describe("Button Component", () => {
     const button = screen.getByRole("button");
     expect(button).toHaveClass("button-ghost-secondary");
   });
+
+  test("renders with default props", () => {
+    const {container} = render(<Button>Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with loading state", () => {
+    const {container} = render(<Button loading>Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with disabled state", () => {
+    const {container} = render(<Button disabled>Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with custom size", () => {
+    const {container} = render(<Button size="small">Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with custom shape", () => {
+    const {container} = render(<Button shape="outline">Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with custom color", () => {
+    const {container} = render(<Button color="secondary">Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with full width", () => {
+    const {container} = render(<Button fullWidth>Click me</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("renders with custom data-testid", () => {
+    const {container} = render(
+      <Button data-testid="test-button">Click me</Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/components/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,104 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Button Component > renders with custom color 1`] = `
+<button
+  aria-busy="false"
+  class="button button-solid-secondary"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with custom data-testid 1`] = `
+<button
+  aria-busy="false"
+  class="button button-solid-primary"
+  data-testid="test-button"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with custom shape 1`] = `
+<button
+  aria-busy="false"
+  class="button button-outline-primary"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with custom size 1`] = `
+<button
+  aria-busy="false"
+  class="button button-small button-solid-primary"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with default props 1`] = `
+<button
+  aria-busy="false"
+  class="button button-solid-primary"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with disabled state 1`] = `
+<button
+  aria-busy="false"
+  class="button button-solid-primary"
+  disabled=""
+  tabindex="-1"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with full width 1`] = `
+<button
+  aria-busy="false"
+  class="button w-full button-solid-primary"
+>
+  Click me
+</button>
+`;
+
+exports[`Button Component > renders with loading state 1`] = `
+<button
+  aria-busy="true"
+  class="button button-solid-primary"
+  disabled=""
+  tabindex="-1"
+>
+  Click me
+  <span
+    class="button-loader-container"
+  >
+    <svg
+      class="circle-loader"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <circle
+          cx="8"
+          cy="8"
+          id="circle_loader_1"
+          r="7"
+        />
+      </defs>
+      <use
+        class="circle-loader-track"
+        href="#circle_loader_1"
+      />
+      <use
+        class="circle-loader-circle"
+        href="#circle_loader_1"
+      />
+    </svg>
+  </span>
+</button>
+`;

--- a/packages/components/lib/components/CircleLoader/CircleLoader.test.tsx
+++ b/packages/components/lib/components/CircleLoader/CircleLoader.test.tsx
@@ -27,4 +27,21 @@ describe("CircleLoader component", () => {
 
     expect(circleLoader).toHaveClass("custom-class");
   });
+
+  test("renders CircleLoader component correctly", () => {
+    const {container} = render(<CircleLoader />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test("renders CircleLoader component with medium size correctly", () => {
+    const {container} = render(<CircleLoader size="medium" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test("renders CircleLoader component with custom class and data-testid correctly", () => {
+    const {container} = render(
+      <CircleLoader className="custom-class" data-testid="loader-test" />,
+    );
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/packages/components/lib/components/CircleLoader/__snapshots__/CircleLoader.test.tsx.snap
+++ b/packages/components/lib/components/CircleLoader/__snapshots__/CircleLoader.test.tsx.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CircleLoader component > renders CircleLoader component correctly 1`] = `
+<div>
+  <svg
+    class="circle-loader"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <circle
+        cx="8"
+        cy="8"
+        id="circle_loader_3"
+        r="7"
+      />
+    </defs>
+    <use
+      class="circle-loader-track"
+      href="#circle_loader_3"
+    />
+    <use
+      class="circle-loader-circle"
+      href="#circle_loader_3"
+    />
+  </svg>
+</div>
+`;
+
+exports[`CircleLoader component > renders CircleLoader component with custom class and data-testid correctly 1`] = `
+<div>
+  <svg
+    class="circle-loader custom-class"
+    data-testid="loader-test"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <circle
+        cx="8"
+        cy="8"
+        id="circle_loader_5"
+        r="7"
+      />
+    </defs>
+    <use
+      class="circle-loader-track"
+      href="#circle_loader_5"
+    />
+    <use
+      class="circle-loader-circle"
+      href="#circle_loader_5"
+    />
+  </svg>
+</div>
+`;
+
+exports[`CircleLoader component > renders CircleLoader component with medium size correctly 1`] = `
+<div>
+  <svg
+    class="circle-loader is-medium"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <circle
+        cx="8"
+        cy="8"
+        id="circle_loader_4"
+        r="7"
+      />
+    </defs>
+    <use
+      class="circle-loader-track"
+      href="#circle_loader_4"
+    />
+    <use
+      class="circle-loader-circle"
+      href="#circle_loader_4"
+    />
+  </svg>
+</div>
+`;

--- a/packages/components/lib/components/Input/Radio.stories.tsx
+++ b/packages/components/lib/components/Input/Radio.stories.tsx
@@ -1,0 +1,28 @@
+import {Meta} from "@storybook/react";
+import {useState} from "react";
+
+import RadioGroup from "./RadioGroup";
+
+export default {
+  component: RadioGroup,
+  title: "components/Radio",
+} as Meta<typeof RadioGroup>;
+
+const themes = ["Dark", "Light", "Auto"] as const;
+
+export const Basic = () => {
+  const [selectedColor, setSelectedColor] = useState<
+    (typeof themes)[number] | undefined
+  >(undefined);
+
+  return (
+    <div>
+      <RadioGroup
+        name="selected-themes"
+        onChange={(v) => setSelectedColor(v)}
+        value={selectedColor}
+        options={themes.map((option) => ({value: option, label: option}))}
+      />
+    </div>
+  );
+};

--- a/packages/components/lib/components/Input/Radio.test.tsx
+++ b/packages/components/lib/components/Input/Radio.test.tsx
@@ -62,4 +62,34 @@ describe("Radio component tests", () => {
     fireEvent.click(radioInput);
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
+
+  it("renders correctly when enabled", () => {
+    const {container} = render(<Radio name="test" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders correctly when disabled", () => {
+    const {container} = render(<Radio name="test" disabled />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders correctly with custom class", () => {
+    const {container} = render(<Radio name="test" className="custom-class" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders correctly with children", () => {
+    const {container} = render(<Radio name="test">Radio Label</Radio>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders correctly with data-testid", () => {
+    const {container} = render(<Radio name="test" data-testid="radio-test" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders correctly when checked", () => {
+    const {container} = render(<Radio name="test" defaultChecked />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/components/lib/components/Input/Radio.test.tsx
+++ b/packages/components/lib/components/Input/Radio.test.tsx
@@ -1,0 +1,65 @@
+import "@testing-library/jest-dom";
+
+import {fireEvent, render, screen} from "@testing-library/react";
+
+import Radio from "./Radio";
+
+describe("Radio component tests", () => {
+  it("renders Radio component correctly", () => {
+    const {getByLabelText} = render(
+      <Radio id="radioId" name="radioName">
+        Radio Label
+      </Radio>,
+    );
+
+    const radioInput = getByLabelText("Radio Label");
+    expect(radioInput).toBeInTheDocument();
+    expect(radioInput).toHaveAttribute("type", "radio");
+  });
+
+  it("applies custom class correctly", () => {
+    render(
+      <Radio
+        id="radio"
+        name="radioName"
+        className="custom-class"
+        data-testid="radio"
+      >
+        Radio Label
+      </Radio>,
+    );
+
+    const labelElement = screen.getByTestId("radio-label");
+    expect(labelElement).toHaveClass("custom-class");
+  });
+
+  it("handles disabled state correctly", () => {
+    render(
+      <Radio id="radioId" name="radioName" disabled data-testid="radio">
+        Radio Label
+      </Radio>,
+    );
+
+    const radioInput = screen.getByTestId("radio-input");
+    expect(radioInput).toBeDisabled();
+  });
+
+  it("fires onChange event correctly", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <Radio
+        id="radioId"
+        name="radioName"
+        onChange={handleChange}
+        data-testid="radio"
+      >
+        Radio Label
+      </Radio>,
+    );
+
+    const radioInput = screen.getByTestId("radio-input");
+    fireEvent.click(radioInput);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/components/lib/components/Input/Radio.tsx
+++ b/packages/components/lib/components/Input/Radio.tsx
@@ -1,0 +1,56 @@
+import {clsx, generateUID} from "@arcnight/utils";
+import {InputHTMLAttributes} from "react";
+
+export interface RadioProps extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * Controls the name of the radio.
+   */
+  name: string;
+  /**
+   * Puts the radio in a disabled state.
+   */
+  disabled?: boolean;
+  /**
+   * Locator for e2e tests.
+   */
+  "data-testid"?: string;
+}
+
+const Radio = ({
+  id = generateUID("radio"),
+  children,
+  className = "inline-flex",
+  name,
+  disabled = false,
+  "data-testid": dataTestId,
+  ...rest
+}: RadioProps) => {
+  return (
+    <label
+      htmlFor={id}
+      className={clsx([
+        !className?.includes("increase-click-surface") && "relative",
+        disabled && "opacity-50 no-pointer-events",
+        className,
+      ])}
+      data-testid={dataTestId && `${dataTestId}-label`}
+    >
+      <input
+        id={id}
+        type="radio"
+        className="radio"
+        name={name}
+        disabled={disabled}
+        data-testid={dataTestId && `${dataTestId}-input`}
+        {...rest}
+      />
+      <span
+        className={clsx("radio-fakeradio shrink-0", children ? "mr-2" : "")}
+        data-testid={dataTestId && `${dataTestId}-span`}
+      />
+      {children}
+    </label>
+  );
+};
+
+export default Radio;

--- a/packages/components/lib/components/Input/RadioGroup.test.tsx
+++ b/packages/components/lib/components/Input/RadioGroup.test.tsx
@@ -1,0 +1,56 @@
+import {render, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RadioGroup from './RadioGroup';
+
+describe('RadioGroup', () => {
+    const themes = ["Dark", "Light", "Auto"] as const;
+
+    it('renders RadioGroup with options', () => {
+      const { getByText } = render(
+        <RadioGroup
+          name="selected-themes"
+          onChange={() => {}}
+          value={undefined}
+          options={themes.map((option) => ({ value: option, label: option }))}
+        />
+      );
+  
+      themes.forEach(theme => {
+        const radioOption = getByText(theme);
+        expect(radioOption).toBeInTheDocument();
+      });
+    });
+  
+    it('calls onChange when a radio option is clicked', () => {
+      const handleChange = vi.fn();
+  
+      const { getByText } = render(
+        <RadioGroup
+          name="selected-themes"
+          onChange={handleChange}
+          value={undefined}
+          options={themes.map((option) => ({ value: option, label: option }))}
+        />
+      );
+  
+      const radioOption = getByText(themes[0]);
+      fireEvent.click(radioOption);
+  
+      expect(handleChange).toHaveBeenCalledWith(themes[0]);
+    });
+
+    it('RadioGroup renders correctly', () => {
+        const selectedColor = 'Dark';
+      
+        const { container } = render(
+          <RadioGroup
+            name="selected-themes"
+            onChange={() => {}}
+            value={selectedColor}
+            options={themes.map((option) => ({value: option, label: option}))}
+          />
+        );
+      
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/packages/components/lib/components/Input/RadioGroup.tsx
+++ b/packages/components/lib/components/Input/RadioGroup.tsx
@@ -1,0 +1,64 @@
+import {clsx} from "@arcnight/utils";
+import {Key, ReactNode} from "react";
+
+import Radio from "./Radio";
+
+export interface RadioGroupProps<T> {
+  /**
+   * Controls the name of the radio.
+   */
+  name: string;
+  /**
+   * Array of radio buttons.
+   */
+  options: {
+    key?: Key;
+    value: T;
+    label: ReactNode;
+    disabled?: boolean;
+  }[];
+  /**
+   * Callback for change selected radio
+   * @param value from options
+   */
+  onChange: (value: T) => void;
+  /**
+   * The current checked value
+   */
+  value: T;
+  className?: string;
+  ["aria-describedby"]?: string;
+}
+
+const RadioGroup = <T,>({
+  name,
+  options,
+  onChange,
+  value,
+  className,
+  "aria-describedby": ariaDescribedBy,
+}: RadioGroupProps<T>) => {
+  return (
+    <>
+      {options.map((option, i) => (
+        <Radio
+          key={option.key || `${i}`}
+          id={`${name}-radio_${i}`}
+          onChange={() => onChange(option.value)}
+          checked={value === option.value}
+          name={name}
+          className={clsx(
+            "inline-flex children-self-center mr-8 mb-2",
+            className,
+          )}
+          disabled={option.disabled}
+          aria-describedby={ariaDescribedBy}
+        >
+          {option.label}
+        </Radio>
+      ))}
+    </>
+  );
+};
+
+export default RadioGroup;

--- a/packages/components/lib/components/Input/__snapshots__/Radio.test.tsx.snap
+++ b/packages/components/lib/components/Input/__snapshots__/Radio.test.tsx.snap
@@ -1,0 +1,109 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Radio component tests > renders correctly when checked 1`] = `
+<label
+  class="relative inline-flex"
+  for="radio_5"
+>
+  <input
+    checked=""
+    class="radio"
+    id="radio_5"
+    name="test"
+    type="radio"
+  />
+  <span
+    class="radio-fakeradio shrink-0"
+  />
+</label>
+`;
+
+exports[`Radio component tests > renders correctly when disabled 1`] = `
+<label
+  class="relative opacity-50 no-pointer-events inline-flex"
+  for="radio_1"
+>
+  <input
+    class="radio"
+    disabled=""
+    id="radio_1"
+    name="test"
+    type="radio"
+  />
+  <span
+    class="radio-fakeradio shrink-0"
+  />
+</label>
+`;
+
+exports[`Radio component tests > renders correctly when enabled 1`] = `
+<label
+  class="relative inline-flex"
+  for="radio_0"
+>
+  <input
+    class="radio"
+    id="radio_0"
+    name="test"
+    type="radio"
+  />
+  <span
+    class="radio-fakeradio shrink-0"
+  />
+</label>
+`;
+
+exports[`Radio component tests > renders correctly with children 1`] = `
+<label
+  class="relative inline-flex"
+  for="radio_3"
+>
+  <input
+    class="radio"
+    id="radio_3"
+    name="test"
+    type="radio"
+  />
+  <span
+    class="radio-fakeradio shrink-0 mr-2"
+  />
+  Radio Label
+</label>
+`;
+
+exports[`Radio component tests > renders correctly with custom class 1`] = `
+<label
+  class="relative custom-class"
+  for="radio_2"
+>
+  <input
+    class="radio"
+    id="radio_2"
+    name="test"
+    type="radio"
+  />
+  <span
+    class="radio-fakeradio shrink-0"
+  />
+</label>
+`;
+
+exports[`Radio component tests > renders correctly with data-testid 1`] = `
+<label
+  class="relative inline-flex"
+  data-testid="radio-test-label"
+  for="radio_4"
+>
+  <input
+    class="radio"
+    data-testid="radio-test-input"
+    id="radio_4"
+    name="test"
+    type="radio"
+  />
+  <span
+    class="radio-fakeradio shrink-0"
+    data-testid="radio-test-span"
+  />
+</label>
+`;

--- a/packages/components/lib/components/Input/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/lib/components/Input/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,0 +1,52 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RadioGroup > RadioGroup renders correctly 1`] = `
+<div>
+  <label
+    class="relative inline-flex children-self-center mr-8 mb-2"
+    for="selected-themes-radio_0"
+  >
+    <input
+      checked=""
+      class="radio"
+      id="selected-themes-radio_0"
+      name="selected-themes"
+      type="radio"
+    />
+    <span
+      class="radio-fakeradio shrink-0 mr-2"
+    />
+    Dark
+  </label>
+  <label
+    class="relative inline-flex children-self-center mr-8 mb-2"
+    for="selected-themes-radio_1"
+  >
+    <input
+      class="radio"
+      id="selected-themes-radio_1"
+      name="selected-themes"
+      type="radio"
+    />
+    <span
+      class="radio-fakeradio shrink-0 mr-2"
+    />
+    Light
+  </label>
+  <label
+    class="relative inline-flex children-self-center mr-8 mb-2"
+    for="selected-themes-radio_2"
+  >
+    <input
+      class="radio"
+      id="selected-themes-radio_2"
+      name="selected-themes"
+      type="radio"
+    />
+    <span
+      class="radio-fakeradio shrink-0 mr-2"
+    />
+    Auto
+  </label>
+</div>
+`;

--- a/packages/components/lib/components/Input/index.ts
+++ b/packages/components/lib/components/Input/index.ts
@@ -1,0 +1,1 @@
+export {default as Radio} from "./Radio";

--- a/packages/components/lib/components/Input/index.ts
+++ b/packages/components/lib/components/Input/index.ts
@@ -1,1 +1,2 @@
 export {default as Radio} from "./Radio";
+export {default as RadioGroup} from "./RadioGroup";

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,9 @@
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
     "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
     "storybook": "storybook dev --no-open -p 6006",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "test:ui": "vitest --ui --coverage.enabled=true",
+    "test:update": "vitest run --update"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -57,6 +59,7 @@
     "@types/text-encoding-utf-8": "^1.0.5",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^1.4.0",
+    "@vitest/ui": "^1.6.0",
     "eslint": "^8.57.0",
     "jsdom": "^24.0.0",
     "prettier": "^3.2.5",

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -6,10 +6,36 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
+      reporters: ["default", "html"],
+      outputFile: './.vitest/index.html',
       environment: "jsdom",
       setupFiles: ["./tests/setup.ts"],
       globals: true,
       css: true,
+      coverage: {
+        include: [
+          "lib/**",
+        ],
+        exclude: [
+          "**\/index**",
+          "coverage/**",
+          "dist/**",
+          "**\/[.]**",
+          "packages/*\/test?(s)/**",
+          "**\/*.d.ts",
+          "**\/virtual:*",
+          "**\/__x00__*",
+          "**\/\x00*",
+          "cypress/**",
+          "test?(s)/**",
+          "test?(-*).?(c|m)[jt]s?(x)",
+          "**\/*{.,-}{test,spec,stories}?(-d).?(c|m)[jt]s?(x)",
+          "**\/__tests__/**",
+          "**\/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
+          "**\/vitest.{workspace,projects}.[jt]s?(on)",
+          "**\/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}",
+        ]
+      }
     },
   }),
 );

--- a/packages/styles/scss/base/_index.scss
+++ b/packages/styles/scss/base/_index.scss
@@ -4,4 +4,5 @@
   "init",
   "custom-properties/index",
   "fonts",
-  "typo";
+  "typo",
+  "forms/index";

--- a/packages/styles/scss/base/forms/_checkbox.scss
+++ b/packages/styles/scss/base/forms/_checkbox.scss
@@ -1,0 +1,150 @@
+.checkbox {
+  &-container {
+    // position: relative; exported inside the component to enable increase-surface-click
+    display: inline-flex;
+  }
+
+  &-input {
+    &#{&} {
+      // Specificity fail for width
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      inline-size: 100%;
+      block-size: 100%;
+      z-index: 1;
+      opacity: 0;
+      margin: 0;
+    }
+  }
+
+  &-fakecheck {
+    display: inline-flex;
+    min-inline-size: rem(20);
+    inline-size: rem(20);
+    block-size: rem(20);
+    margin-block: auto;
+    border-radius: var(--border-radius-sm);
+    border: 1px solid var(--field-norm);
+    background-color: var(--field-background-color);
+    color: var(--field-text-color);
+    transition: 0.15s easing(ease-out-cubic);
+
+    &-img {
+      margin: auto;
+      transform: scale(0);
+      transition: 0.15s transform easing(ease-out-back);
+    }
+  }
+
+  &-input:hover + &-fakecheck {
+    border-color: var(--norm);
+    background-color: var(--field-hover-background-color);
+    color: var(--field-hover-text-color);
+  }
+
+  @supports not selector(:focus-visible) {
+    &-input:focus + &-fakecheck {
+      border-color: var(--norm);
+      box-shadow: 0 0 0 #{$focus-ring-size} var(--focus-ring);
+      background-color: var(--field-focus-background-color);
+      color: var(--field-focus-text-color);
+    }
+
+    &-input:focus:hover + &-fakecheck {
+      border-color: var(--norm-hover);
+    }
+  }
+
+  @supports selector(:focus-visible) {
+    &-input:focus-visible + &-fakecheck {
+      border-color: var(--norm);
+      box-shadow: 0 0 0 #{$focus-ring-size} var(--focus-ring);
+      background-color: var(--field-focus-background-color);
+      color: var(--field-focus-text-color);
+    }
+
+    &-input:focus-visible:hover + &-fakecheck {
+      border-color: var(--norm-hover);
+    }
+  }
+
+  &-input[aria-invalid="true"] + &-fakecheck {
+    border-color: var(--danger);
+    background-color: var(--field-background-color);
+    color: var(--danger);
+  }
+
+  &-input[disabled] + &-fakecheck {
+    border-color: var(--field-disabled);
+    background-color: var(--field-disabled-background-color);
+    color: var(--field-disabled-text-color);
+  }
+
+  /*
+   * Checked state
+   */
+  &-input:checked + &-fakecheck {
+    border-color: var(--norm);
+    background-color: var(--norm);
+    color: var(--norm-contrast);
+  }
+
+  &-input:checked:hover + &-fakecheck {
+    border-color: var(--norm-hover);
+    background-color: var(--norm-hover);
+    color: var(--norm-contrast);
+  }
+
+  @supports not selector(:focus-visible) {
+    &-input:checked:focus + &-fakecheck {
+      border-color: var(--norm);
+      box-shadow: 0 0 0 #{$focus-ring-size} var(--focus-ring);
+      background-color: var(--norm);
+      color: var(--norm-contrast);
+    }
+
+    &-input:checked:focus:hover + &-fakecheck {
+      border-color: var(--norm-hover);
+    }
+  }
+
+  @supports selector(:focus-visible) {
+    &-input:checked:focus-visible + &-fakecheck {
+      border-color: var(--norm);
+      box-shadow: 0 0 0 #{$focus-ring-size} var(--focus-ring);
+      background-color: var(--norm);
+      color: var(--norm-contrast);
+    }
+
+    &-input:checked:focus-visible:hover + &-fakecheck {
+      border-color: var(--norm-hover);
+      background-color: var(--norm-hover);
+    }
+  }
+
+  &-input:checked[aria-invalid="true"] + &-fakecheck {
+    border-color: var(--danger);
+    background-color: var(--danger);
+    color: var(--danger-contrast);
+  }
+
+  &-input:checked[disabled] + &-fakecheck,
+  &-input:checked[disabled]:indeterminate + &-fakecheck {
+    border-color: var(--field-disabled);
+    background-color: var(--field-disabled);
+    color: var(--norm-contrast);
+  }
+
+  &-input:checked:indeterminate + &-fakecheck {
+    border-color: var(--field-norm);
+    background-color: var(--field-background-color);
+    color: var(--field-text-color);
+  }
+
+  &-input:checked + &-fakecheck &-fakecheck-img,
+  &-input:indeterminate + &-fakecheck &-fakecheck-img {
+    transform: scale(1);
+    transition-delay: 0.1s;
+  }
+}

--- a/packages/styles/scss/base/forms/_index.scss
+++ b/packages/styles/scss/base/forms/_index.scss
@@ -1,0 +1,3 @@
+@import
+  "checkbox",
+  "radio";

--- a/packages/styles/scss/base/forms/_radio.scss
+++ b/packages/styles/scss/base/forms/_radio.scss
@@ -1,0 +1,113 @@
+.radio {
+  @extend .sr-only;
+
+  &-fakeradio {
+    @extend .checkbox-fakecheck;
+
+    border-radius: 50%;
+
+    &::before {
+      content: "";
+      inline-size: em(10);
+      block-size: em(10);
+      margin: auto;
+      border-radius: 50%;
+      background: transparent;
+      transform: scale(0);
+      transition: 0.15s easing(ease-out-cubic),
+      0.15s transform easing(ease-out-back);
+    }
+  }
+
+  &:hover + &-fakeradio {
+    border-color: var(--norm);
+    background-color: var(
+      --field-focus-background-color,
+      var(--background-norm)
+    );
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus + &-fakeradio {
+      border-color: var(--norm);
+      box-shadow: 0 0 0 #{$focus-ring-size} var(--focus-ring);
+      background-color: var(--field-focus-background-color);
+      color: var(--field-focus-text-color);
+    }
+
+    &:focus:hover + &-fakeradio {
+      border-color: var(--norm-hover);
+    }
+  }
+
+  @supports selector(:focus-visible) {
+    &:focus-visible + &-fakeradio {
+      border-color: var(--norm);
+      box-shadow: 0 0 0 #{$focus-ring-size} var(--focus-ring);
+      background-color: var(--field-focus-background-color);
+      color: var(--field-focus-text-color);
+    }
+
+    &:focus-visible:hover + &-fakeradio {
+      border-color: var(--norm-hover);
+    }
+  }
+
+  &[aria-invalid="true"] + &-fakeradio {
+    border-color: var(--danger);
+    background-color: var(--field-background-color);
+  }
+
+  &[disabled] + &-fakeradio {
+    border-color: var(--field-disabled);
+    background-color: var(
+      --field-disabled-background-color,
+      var(--background-norm)
+    );
+  }
+
+  /*
+   * Checked state
+   */
+  &:checked + &-fakeradio {
+    &::before {
+      transform: scale(1);
+      background-color: var(--norm);
+    }
+  }
+
+  @supports not selector(:focus-visible) {
+    &:checked:focus:hover + &-fakeradio {
+      border-color: var(--norm-hover);
+
+      &::before {
+        background-color: var(--norm-hover);
+      }
+    }
+  }
+
+  @supports selector(:focus-visible) {
+    &:checked:focus-visible:hover + &-fakeradio {
+      border-color: var(--norm-hover);
+
+      &::before {
+        background-color: var(--norm-hover);
+      }
+    }
+  }
+
+  &:checked[aria-invalid="true"] + &-fakeradio::before {
+    background-color: var(--danger);
+  }
+
+  &:checked[disabled] + &-fakeradio::before {
+    background-color: var(--field-disabled);
+  }
+
+  /*
+   * Modifiers
+   */
+  &--ontop &-fakeradio {
+    margin-block-start: 0;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,7 @@ __metadata:
     "@types/text-encoding-utf-8": "npm:^1.0.5"
     "@vitejs/plugin-react": "npm:^4.2.1"
     "@vitest/coverage-v8": "npm:^1.4.0"
+    "@vitest/ui": "npm:^1.6.0"
     eslint: "npm:^8.57.0"
     jsdom: "npm:^24.0.0"
     prettier: "npm:^3.2.5"
@@ -3013,6 +3014,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.25
+  resolution: "@polka/url@npm:1.0.0-next.25"
+  checksum: 10c0/ef61f0a0fe94bb6e1143fc5b9d5a12e6ca9dbd2c57843ebf81db432c21b9f1005c09e8a1ef8b6d5ddfa42146ca65b640feb2d353bd0d3546da46ba59e48a5349
+  languageName: node
+  linkType: hard
+
 "@radix-ui/primitive@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/primitive@npm:1.0.1"
@@ -5332,6 +5340,23 @@ __metadata:
   dependencies:
     tinyspy: "npm:^2.2.0"
   checksum: 10c0/df66ea6632b44fb76ef6a65c1abbace13d883703aff37cd6d062add6dcd1b883f19ce733af8e0f7feb185b61600c6eb4042a518e4fb66323d0690ec357f9401c
+  languageName: node
+  linkType: hard
+
+"@vitest/ui@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@vitest/ui@npm:1.6.0"
+  dependencies:
+    "@vitest/utils": "npm:1.6.0"
+    fast-glob: "npm:^3.3.2"
+    fflate: "npm:^0.8.1"
+    flatted: "npm:^3.2.9"
+    pathe: "npm:^1.1.1"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^2.0.4"
+  peerDependencies:
+    vitest: 1.6.0
+  checksum: 10c0/1d2f971f1efb9f9b22af2881e5ed66ceca8a7f091c31bfb6181ea2cb63c0cf3ff00272433892a38be67721dad26c3502b084f3c8d63c574f743ed45ae0016582
   languageName: node
   linkType: hard
 
@@ -8634,6 +8659,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fflate@npm:^0.8.1":
+  version: 0.8.2
+  resolution: "fflate@npm:0.8.2"
+  checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
+  languageName: node
+  linkType: hard
+
 "figures@npm:3.2.0, figures@npm:^3.0.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -11713,6 +11745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mrmime@npm:2.0.0"
+  checksum: 10c0/312b35ed288986aec90955410b21ed7427fd1e4ee318cb5fc18765c8d029eeded9444faa46589e5b1ed6b35fb2054a802ac8dcb917ddf6b3e189cb3bf11a965c
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.0.0":
   version: 2.0.0
   resolution: "ms@npm:2.0.0"
@@ -14319,6 +14358,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sirv@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "sirv@npm:2.0.4"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10c0/68f8ee857f6a9415e9c07a1f31c7c561df8d5f1b1ba79bee3de583fa37da8718def5309f6b1c6e2c3ef77de45d74f5e49efc7959214443aa92d42e9c99180a4e
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -15067,6 +15117,13 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
+  languageName: node
+  linkType: hard
+
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Introduce Radio component to handle radio inputs. This component includes styling and accessibility features for radio inputs. It allows specifying the name, disabled state, and data-testid for end-to-end tests.
- Introduce RadioGroup component to handle a group of radio inputs. This component simplifies the management of multiple radio buttons by providing a group container with options. Each option includes a key, value, label, and optional disabled state. RadioGroup handles the selection state and onChange callback for updating the selected value.

- Added snapshot tests for Button component.
- Added snapshot tests for CircleLoader component.
- Added snapshot tests for Radio component.
- Added unit and snapshot tests for RadioGroup component.

- Added a story for the Radio component to demonstrate its usage in Storybook. The story showcases a basic RadioGroup with options to select different themes (Dark, Light, Auto).
