### PR TITLE
feat(components): add Kbd component

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -3,7 +3,9 @@ import type {StorybookConfig} from "@storybook/react-vite";
 const config: StorybookConfig = {
   stories: ["../lib/**/*.mdx", "../lib/**/*.stories.tsx"],
   addons: [
-    "@storybook/addon-links", "@storybook/addon-storysource", "@storybook/addon-essentials"
+    "@storybook/addon-links",
+    "@storybook/addon-storysource",
+    "@storybook/addon-essentials",
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -20,10 +20,10 @@ const config: ArcnightConfig = {
 const preview: Preview = {
   parameters: {
     viewMode: "docs",
-    actions: { argTypesRegex: "^on[A-Z].*" },
-    controls: { expanded: true },
+    actions: {argTypesRegex: "^on[A-Z].*"},
+    controls: {expanded: true},
     previewTabs: {
-      canvas: { hidden: true },
+      canvas: {hidden: true},
     },
   },
   decorators: [
@@ -33,7 +33,7 @@ const preview: Preview = {
         <Story />
       </ConfigProvider>
     ),
-  ]
-}
+  ],
+};
 
 export default preview;

--- a/packages/components/lib/components/Kbd/Kbd.scss
+++ b/packages/components/lib/components/Kbd/Kbd.scss
@@ -1,0 +1,10 @@
+@import "@arcnight/styles/scss/lib";
+
+.kbd {
+	padding-block: 0;
+	padding-inline: em(4);
+	background-color: var(--background-strong);
+	color: var(--text-norm);
+	border: 1px solid var(--border-norm);
+	border-radius: var(--border-radius-sm);
+}

--- a/packages/components/lib/components/Kbd/Kbd.stories.tsx
+++ b/packages/components/lib/components/Kbd/Kbd.stories.tsx
@@ -1,0 +1,8 @@
+import Kbd from "./Kbd";
+
+export default {
+  component: Kbd,
+  title: "components/Kbd",
+};
+
+export const Basic = () => <Kbd shortcut="N" />;

--- a/packages/components/lib/components/Kbd/Kbd.test.tsx
+++ b/packages/components/lib/components/Kbd/Kbd.test.tsx
@@ -1,0 +1,37 @@
+import {render} from "@testing-library/react";
+
+import Kbd from "./Kbd";
+
+describe("Kbd component", () => {
+  it("should render with className kbd and additional className", () => {
+    const {container} = render(
+      <Kbd shortcut="N" className="should-be-passed" />,
+    );
+
+    expect(container.firstChild).toHaveClass("kbd");
+    expect(container.firstChild).toHaveClass("should-be-passed");
+  });
+
+  it("should render element with text content N", () => {
+    const {container} = render(<Kbd shortcut="N" />);
+
+    expect(container.textContent).toBe("N");
+  });
+
+  it("renders correctly with a single key shortcut", () => {
+    const {asFragment} = render(<Kbd shortcut="A" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders correctly with a combination key shortcut", () => {
+    const {asFragment} = render(<Kbd shortcut="Ctrl+C" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders correctly with additional className", () => {
+    const {asFragment} = render(
+      <Kbd shortcut="Ctrl+V" className="custom-class" />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/components/lib/components/Kbd/Kbd.tsx
+++ b/packages/components/lib/components/Kbd/Kbd.tsx
@@ -1,0 +1,23 @@
+import "./Kbd.scss";
+
+import {clsx} from "@arcnight/utils";
+import {ComponentPropsWithoutRef} from "react";
+import {c} from "ttag";
+
+export interface KbdProps extends ComponentPropsWithoutRef<"kbd"> {
+  shortcut: String;
+}
+
+const Kbd = ({shortcut, className, ...rest}: KbdProps) => {
+  return (
+    <kbd
+      className={clsx("kbd", className)}
+      aria-label={c("Label").t`Keyboard shortcut: ${shortcut}`}
+      {...rest}
+    >
+      {shortcut}
+    </kbd>
+  );
+};
+
+export default Kbd;

--- a/packages/components/lib/components/Kbd/__snapshots__/Kbd.test.tsx.snap
+++ b/packages/components/lib/components/Kbd/__snapshots__/Kbd.test.tsx.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Kbd component > renders correctly with a combination key shortcut 1`] = `
+<DocumentFragment>
+  <kbd
+    aria-label="Keyboard shortcut: Ctrl+C"
+    class="kbd"
+  >
+    Ctrl+C
+  </kbd>
+</DocumentFragment>
+`;
+
+exports[`Kbd component > renders correctly with a single key shortcut 1`] = `
+<DocumentFragment>
+  <kbd
+    aria-label="Keyboard shortcut: A"
+    class="kbd"
+  >
+    A
+  </kbd>
+</DocumentFragment>
+`;
+
+exports[`Kbd component > renders correctly with additional className 1`] = `
+<DocumentFragment>
+  <kbd
+    aria-label="Keyboard shortcut: Ctrl+V"
+    class="kbd custom-class"
+  >
+    Ctrl+V
+  </kbd>
+</DocumentFragment>
+`;

--- a/packages/components/lib/components/Kbd/index.ts
+++ b/packages/components/lib/components/Kbd/index.ts
@@ -1,0 +1,1 @@
+export {default as Kbd} from "./Kbd";

--- a/packages/components/lib/components/index.ts
+++ b/packages/components/lib/components/index.ts
@@ -3,4 +3,5 @@ export * from "./Button";
 export * from "./CircleLoader";
 export * from "./Icon";
 export * from "./Input";
+export * from "./Kbd";
 export * from "./Logo";


### PR DESCRIPTION
- Added `Kbd` component with associated SCSS and TypeScript files.
- Implemented `Kbd` component to display keyboard shortcuts with appropriate styling and accessibility labels.
- Updated Storybook configuration to improve readability of `main.ts` and `preview.tsx` files.
- Exported `Kbd` component in the components index file for easier imports.
- Created `Kbd.stories.tsx` file to define stories for the `Kbd` component.
- Added a basic story (`Basic`) to demonstrate the usage of the `Kbd` component with a shortcut "N".
- Created `Kbd.test.tsx` file to add tests for the `Kbd` component.
- Added tests to ensure that the `Kbd` component renders with the correct class names and text content.
- Included snapshot tests to verify the rendering of `Kbd` component with different shortcut values and additional class names.